### PR TITLE
Add more reasonable version pins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,10 +49,10 @@ keywords =
 
 [options]
 install_requires =
-    click==7.1.1
+    click
     tqdm
-    networkx>=2.1
-    pandas==1.0.3
+    networkx>=2.4
+    pandas
     numpy
     scipy
     statsmodels


### PR DESCRIPTION
Was there a reason click and pandas were pinned? In general pinning based on the patch version is super restrictive to everyone else. It's likely the case that most mature software only adds bugfixes for patch version changes